### PR TITLE
Added `nintendoclients` as a dependency

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -5,3 +5,4 @@ nest-asyncio
 pyqt5
 IPython
 pygments
+nintendoclients


### PR DESCRIPTION
Attempting to run `client.py` without `nintendoclients` installed causes `love2.py` to throw an error, as it tries to import `nintendo` & `nintendo.nex`

Though, this does have the side-effect of Microsoft Visual C++ 14.0 being required as well, due to `nintendoclients` depending on `netifaces` which requires it during compilation.