### PR TITLE
Refactor service types

### DIFF
--- a/api/networks.py
+++ b/api/networks.py
@@ -1,24 +1,44 @@
 from enum import IntEnum
 from api.public import nintendoBotFC, pretendoBotFC
 
-# Selectable networks
-class NetworkIDsToName(IntEnum):
-	nintendo = 0
-	pretendo = 1
-	
-def getBotFriendCodeFromNetworkId(network:int):
-    match network:
-        case 0:
-            return nintendoBotFC
-        case 1:
-            return pretendoBotFC
 
-def nameToNetworkId(network:int):
-    if network == None:
-        network = 0
-    else:
-        try:
-            network = NetworkIDsToName[network].value
-        except:
-            network = 0
-    return network
+class InvalidNetworkError(Exception):
+    pass
+
+
+class NetworkType(IntEnum):
+    """Selectable network types."""
+    NINTENDO = 0
+    PRETENDO = 1
+
+    def friend_code(self) -> str:
+        """Returns the configured friend code for this network type."""
+        match self:
+            case self.NINTENDO:
+                return nintendoBotFC
+            case self.PRETENDO:
+                return pretendoBotFC
+
+    def column_name(self) -> str:
+        """Returns the database column name for this network type."""
+        match self:
+            case self.NINTENDO:
+                return "nintendo_friends"
+            case self.PRETENDO:
+                return "pretendo_friends"
+
+    def lower_name(self) -> str:
+        """Returns a lowercase name of this enum member's name for API compatibility."""
+        return self.name.lower()
+
+
+def nameToNetworkType(network_name: str) -> NetworkType:
+    # Assume Nintendo Network as a fallback.
+    if network_name is None:
+        return NetworkType.NINTENDO
+
+    try:
+        # All enum members are uppercase, so ensure we are, too.
+        return NetworkType[network_name.upper()]
+    except:
+        return NetworkType.NINTENDO

--- a/server/backend.py
+++ b/server/backend.py
@@ -10,7 +10,7 @@ sys.path.append('../')
 from api.private import SERIAL_NUMBER, MAC_ADDRESS, DEVICE_CERT, DEVICE_NAME, REGION, LANGUAGE, NINTENDO_PID, PRETENDO_PID, PID_HMAC, NINTENDO_NEX_PASSWORD, PRETENDO_NEX_PASSWORD
 from api import *
 from api.love2 import *
-from api.networks import NetworkIDsToName
+from api.networks import NetworkType, InvalidNetworkError
 
 import logging
 logging.basicConfig(level=logging.INFO)
@@ -21,7 +21,7 @@ quicker = 15
 begun = time.time()
 scrape_only = False
 
-network:int = 0
+network: NetworkType = NetworkType.NINTENDO
 
 async def main():
 	while True:
@@ -29,7 +29,7 @@ async def main():
 		print('Grabbing new friends...')
 		with sqlite3.connect('sqlite/fcLibrary.db') as con:
 			cursor = con.cursor()
-			cursor.execute('SELECT friendCode, lastAccessed FROM ' + NetworkIDsToName(network).name + "_friends")
+			cursor.execute('SELECT friendCode, lastAccessed FROM ' + network.column_name())
 			result = cursor.fetchall()
 			if not result:
 				continue
@@ -45,19 +45,17 @@ async def main():
 					client.set_title(0x0004013000003202, 20) # to be honest, this should be seperate between networks, so if one eg, gets banned, you still get to keep the friend code for the other network, but i'm lazy.
 					client.set_locale(REGION, LANGUAGE)
 
-					if network == 0: # Nintendo Network
+					if network == NetworkType.NINTENDO:
 						client.set_url("nasc.nintendowifi.net")
 						PID = NINTENDO_PID
 						NEX_PASSWORD = NINTENDO_NEX_PASSWORD
-						
-					elif network == 1:
+					elif network == NetworkType.PRETENDO:
 						client.set_url("nasc.pretendo.cc")
 						client.context.set_authority(None)
 						PID = PRETENDO_PID
 						NEX_PASSWORD = PRETENDO_NEX_PASSWORD
-						
 					else:
-						raise Exception(NetworkIDsToName(network).name + " is not a valid network")
+						raise InvalidNetworkError(f"Network type {network} is not configured for querying")
 					
 					client.set_device(SERIAL_NUMBER, MAC_ADDRESS, DEVICE_CERT, DEVICE_NAME)
 					client.set_user(PID , PID_HMAC)
@@ -88,10 +86,13 @@ async def main():
 
 							removeList = []
 							cleanUp = []
-							if network == 1:
+
+							# The add_friend_by_principal_ids method is not yet
+							# implemented on Pretendo, so this is a fix for now.
+							if network == NetworkType.PRETENDO:
 								for friend_pid in rotation:
 									time.sleep(delay / quicker)
-									await friends_client.add_friend_by_principal_id(0, friend_pid) # the add_friend_by_principal_ids hasn't been implemented yet on pretendo, so this is a fix for now. 
+									await friends_client.add_friend_by_principal_id(0, friend_pid)
 							else:
 								time.sleep(delay)
 								await friends_client.add_friend_by_principal_ids(0, rotation)
@@ -112,7 +113,8 @@ async def main():
 									cleanUp.append(t1.pid)
 
 							for remover in removeList:
-								cursor.execute('DELETE FROM ' + NetworkIDsToName(network).name + "_friends" + ' WHERE friendCode = ?', (str(convertPrincipalIdtoFriendCode(remover)).zfill(12),))
+								column_name = network.column_name()
+								cursor.execute('DELETE FROM ' + column_name + ' WHERE friendCode = ?', (str(convertPrincipalIdtoFriendCode(remover)).zfill(12),))
 								cursor.execute('DELETE FROM discordFriends WHERE friendCode = ? AND network = ?', (str(convertPrincipalIdtoFriendCode(remover)).zfill(12), str(network)))
 							con.commit()
 
@@ -132,9 +134,9 @@ async def main():
 									if not gameDescription: gameDescription = ''
 									joinable = bool(game.presence.join_availability_flag)
 
-									cursor.execute('UPDATE ' + NetworkIDsToName(network).name + "_friends" + ' SET online = ?, titleID = ?, updID = ?, joinable = ?, gameDescription = ?, lastOnline = ? WHERE friendCode = ?', (True, game.presence.game_key.title_id, game.presence.game_key.title_version, joinable, gameDescription, time.time(), str(convertPrincipalIdtoFriendCode(users[-1])).zfill(12)))
+									cursor.execute('UPDATE ' + network.column_name() + ' SET online = ?, titleID = ?, updID = ?, joinable = ?, gameDescription = ?, lastOnline = ? WHERE friendCode = ?', (True, game.presence.game_key.title_id, game.presence.game_key.title_version, joinable, gameDescription, time.time(), str(convertPrincipalIdtoFriendCode(users[-1])).zfill(12)))
 								for user in [ h for h in rotation if not h in users ]:
-									cursor.execute('UPDATE ' + NetworkIDsToName(network).name + "_friends" + ' SET online = ?, titleID = ?, updID = ? WHERE friendCode = ?', (False, 0, 0, str(convertPrincipalIdtoFriendCode(user)).zfill(12)))
+									cursor.execute('UPDATE ' + network.column_name() + ' SET online = ?, titleID = ?, updID = ? WHERE friendCode = ?', (False, 0, 0, str(convertPrincipalIdtoFriendCode(user)).zfill(12)))
 
 								con.commit()
 
@@ -176,7 +178,7 @@ async def main():
 										jeuFavori = j1[0].game_key.title_id
 									else:
 										comment = ''
-									cursor.execute('UPDATE ' + NetworkIDsToName(network).name + "_friends" + ' SET username = ?, message = ?, mii = ?, jeuFavori = ? WHERE friendCode = ?', (username, comment, face, jeuFavori, str(convertPrincipalIdtoFriendCode(ti.pid)).zfill(12)))
+									cursor.execute('UPDATE ' + network.column_name() + ' SET username = ?, message = ?, mii = ?, jeuFavori = ? WHERE friendCode = ?', (username, comment, face, jeuFavori, str(convertPrincipalIdtoFriendCode(ti.pid)).zfill(12)))
 									con.commit()
 
 							for friend in rotation + cleanUp:
@@ -194,10 +196,10 @@ async def main():
 if __name__ == '__main__':
 	try:
 		parser = argparse.ArgumentParser()
-		parser.add_argument('-n', '--network', choices=[member.name.lower() for member in NetworkIDsToName], required=True)
+		parser.add_argument('-n', '--network', choices=[member.lower_name() for member in NetworkType], required=True)
 		args = parser.parse_args()
 
-		network = NetworkIDsToName[args.network.lower()].value
+		network = NetworkType[args.network.upper()]
 		startDBTime(begun, network)
 		anyio.run(main)
 	except (KeyboardInterrupt, Exception) as e:

--- a/server/backend.py
+++ b/server/backend.py
@@ -19,7 +19,6 @@ delay = 2
 since = 0
 quicker = 15
 begun = time.time()
-startDBTime(begun)
 scrape_only = False
 
 network:int = 0
@@ -68,9 +67,6 @@ async def main():
 					s = settings.load('friends')
 					s.configure("ridfebb9", 20000)
 
-					if network == 1: # If the app starts randomly hanging on Pretendo, try removing this, and the next line.
-						s["prudp.ping_timeout"] = 100000000000 # oh my god this is horrifying, but it makes it works, so who am i to care
-						
 					async with backend.connect(s, response.host, response.port) as be:
 						async with be.login(str(PID), NEX_PASSWORD) as client:
 							friends_client = friends.FriendsClientV1(client)
@@ -202,10 +198,6 @@ if __name__ == '__main__':
 		args = parser.parse_args()
 
 		network = NetworkIDsToName[args.network.lower()].value
-		if network == NetworkIDsToName.pretendo.value:
-			# Pretendo shouldn't care about a delay, like maybe nintendo? Since this was here just to prevent spamming Nintendo, we don't need it for pretendo. It will also make it faster.
-			# Maybe later it should just not have a delay for all networks?
-			delay, quicker = 0, 1
 		startDBTime(begun, network)
 		anyio.run(main)
 	except (KeyboardInterrupt, Exception) as e:

--- a/server/discord.py
+++ b/server/discord.py
@@ -4,7 +4,7 @@ sys.path.append('../')
 from api import *
 from api.love2 import *
 from api.private import CLIENT_ID, CLIENT_SECRET, HOST
-from api.networks import NetworkIDsToName, nameToNetworkId
+from api.networks import NetworkType
 
 API_ENDPOINT:str = 'https://discord.com/api/v10'
 
@@ -63,10 +63,10 @@ class Discord():
 			if presence['gameDescription']:
 				data['activities'][0]['details'] = presence['gameDescription']
 			if userData['User']['username'] and bool(config[0]):
-				data['activities'][0]['buttons'] = [{'label': 'Profile', 'url': HOST + '/user/' + userData['User']['friendCode'] + '/?network=' + NetworkIDsToName(network).name},]
+				data['activities'][0]['buttons'] = [{'label': 'Profile', 'url': HOST + '/user/' + userData['User']['friendCode'] + '/?network=' + NetworkType(network).name},]
 			if userData['User']['username'] and game['icon_url'] and bool(config[1]):
 				data['activities'][0]['assets']['small_image'] = userData['User']['mii']['face']
-				data['activities'][0]['assets']['small_text'] = '-'.join(userData['User']['friendCode'][i:i+4] for i in range(0, 12, 4)) + ' on ' + NetworkIDsToName(network).name.capitalize()
+				data['activities'][0]['assets']['small_text'] = '-'.join(userData['User']['friendCode'][i:i+4] for i in range(0, 12, 4)) + ' on ' + NetworkType(network).name.capitalize()
 			if session:
 				data['token'] = session
 			headers = {
@@ -193,7 +193,7 @@ while True:
 				continue
 			for r in discordFriends:
 				print('[RUNNING %s - %s]' % (r[0], r[1]))
-				cursor.execute('SELECT * FROM ' + NetworkIDsToName(r[2]).name + '_friends WHERE friendCode = ?', (r[1],))
+				cursor.execute('SELECT * FROM ' + NetworkType(r[2]).column_name() + ' WHERE friendCode = ?', (r[1],))
 				v2 = cursor.fetchone()
 				cursor.execute('SELECT * FROM discord WHERE ID = ?', (r[0],))
 				v3 = cursor.fetchone()


### PR DESCRIPTION
This implements some changes to allow for somewhat smoother refinements in future follow-up pull requests. Instead of having hardcoded integer checks everywhere, enum values are more heavily utilized throughout the codebase.

Note: Changes related to the API (e.g. its mixed use of network service names vs. their underlying service IDs) have not been thoroughly tested.

Future areas of improvement:
- Adopt SQLAlchemy's [ORM model](https://docs.sqlalchemy.org/en/20/orm/) in many locations
- Attempt to split large while loop within backend.py once database-dependent code is modified
- ...?