### PR TITLE
Add MySQL (MariaDB) support

### DIFF
--- a/api/template.private.py
+++ b/api/template.private.py
@@ -42,3 +42,13 @@ CLIENT_SECRET:str = "" # Taken from OAuth2 page
 HOST:str = ""
 # http(s)://subdomain.domain.extension
 # No ending slash!
+
+### DATABASE-SPECIFIC ###
+
+IS_SQLITE:bool = True # SQLite should generally only be used for testing. It is recommended to use MySQL software like MariaDB
+
+# MySQL specifc
+DB_HOST:str = "localhost"
+DB_NAME:str = "3dsrpc"
+DB_USERNAME:str = "username"
+DB_PASSWORD:str = "password"

--- a/api/util.py
+++ b/api/util.py
@@ -2,9 +2,11 @@
 
 import os, sys
 import sqlite3
+import pymysql
 import time
 import threading
 import traceback
+from api.private import DB_HOST, DB_NAME, DB_PASSWORD, DB_USERNAME, IS_SQLITE
 if os.name == 'nt':
     import pyreadline3
 else:
@@ -40,12 +42,22 @@ def getPath(path):
     return os.path.join(root, path)
 
 def startDBTime(time, network):
-    with sqlite3.connect('sqlite/fcLibrary.db') as con:
+    with connectDB() as con:
         cursor = con.cursor()
         cursor.execute('DELETE FROM config WHERE network=' + str(network)) # doing this isn't the most intelegent of ideas but oh well (i hope you don't need to ever add another config :D)
         cursor.execute('INSERT INTO config (BACKEND_UPTIME, NETWORK) VALUES (%s, %s)' % (time, network,))
         con.commit()
-
+def connectDB():
+	if IS_SQLITE:
+		return sqlite3.connect('sqlite/fcLibrary.db')
+	else:
+		return pymysql.connect( 
+			host=DB_HOST, 
+			user=DB_USERNAME,  
+			password = DB_PASSWORD, 
+			db=DB_NAME, 
+		)
+    
 try:
     terminalSize = os.get_terminal_size(0).columns - 2
 except OSError:

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -3,8 +3,9 @@ flask
 nintendoclients>=2.1.0
 flask-limiter<=2.9.2 # Until 3.0 fixes "multiple values for argument 'key_func'"
 gevent
-SQLAlchemy<1.4.46
+SQLAlchemy<2
 Flask-SQLAlchemy # Using deprecated features, apparently
 xmltodict
 Pillow
 pycryptodomex
+pymysql # Required for MySQL support

--- a/server/server.py
+++ b/server/server.py
@@ -16,7 +16,6 @@ app = Flask(__name__)
 if IS_SQLITE:
     app.config['SQLALCHEMY_DATABASE_URI'] = 'sqlite:///' + os.path.abspath('sqlite/fcLibrary.db')
 else:
-    print('mysql+pymysql://' + urllib.parse.quote_plus(DB_USERNAME) + ':' + urllib.parse.quote_plus(DB_PASSWORD) + '@' + DB_HOST + '/' + urllib.parse.quote_plus(DB_NAME))
     app.config['SQLALCHEMY_DATABASE_URI'] = 'mysql+pymysql://' + urllib.parse.quote_plus(DB_USERNAME) + ':' + urllib.parse.quote_plus(DB_PASSWORD) + '@' + DB_HOST + '/' + urllib.parse.quote_plus(DB_NAME)
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db = SQLAlchemy(app)

--- a/server/sqlite/sqlitetomysql.py
+++ b/server/sqlite/sqlitetomysql.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+# Taken from https://stackoverflow.com/questions/18671/quick-easy-way-to-migrate-sqlite3-to-mysql
+
+import re
+import fileinput
+
+def this_line_is_useless(line):
+    useless_es = [
+        'BEGIN TRANSACTION',
+        'COMMIT',
+        'sqlite_sequence',
+        'CREATE UNIQUE INDEX',
+        'PRAGMA foreign_keys=OFF',
+    ]
+    for useless in useless_es:
+        if re.search(useless, line):
+            return True
+
+def has_primary_key(line):
+    return bool(re.search(r'PRIMARY KEY', line))
+
+searching_for_end = False
+for line in fileinput.input():
+    if this_line_is_useless(line):
+        continue
+
+    # this line was necessary because '');
+    # would be converted to \'); which isn't appropriate
+    if re.match(r".*, ''\);", line):
+        line = re.sub(r"''\);", r'``);', line)
+
+    if re.match(r'^CREATE TABLE.*', line):
+        searching_for_end = True
+
+    m = re.search('CREATE TABLE "?(\w*)"?(.*)', line)
+    if m:
+        name, sub = m.groups()
+        line = "DROP TABLE IF EXISTS %(name)s;\nCREATE TABLE IF NOT EXISTS `%(name)s`%(sub)s\n"
+        line = line % dict(name=name, sub=sub)
+    else:
+        m = re.search('INSERT INTO "(\w*)"(.*)', line)
+        if m:
+            line = 'INSERT INTO %s%s\n' % m.groups()
+            line = line.replace('"', r'\"')
+            line = line.replace('"', "'")
+    line = re.sub(r"([^'])'t'(.)", "\1THIS_IS_TRUE\2", line)
+    line = line.replace('THIS_IS_TRUE', '1')
+    line = re.sub(r"([^'])'f'(.)", "\1THIS_IS_FALSE\2", line)
+    line = line.replace('THIS_IS_FALSE', '0')
+
+    # Add auto_increment if it is not there since sqlite auto_increments ALL
+    # primary keys
+    if searching_for_end:
+        if re.search(r"integer(?:\s+\w+)*\s*PRIMARY KEY(?:\s+\w+)*\s*,", line):
+            line = line.replace("PRIMARY KEY", "PRIMARY KEY AUTO_INCREMENT")
+        # replace " and ' with ` because mysql doesn't like quotes in CREATE commands 
+        if line.find('DEFAULT') == -1:
+            line = line.replace(r'"', r'`').replace(r"'", r'`')
+        else:
+            parts = line.split('DEFAULT')
+            parts[0] = parts[0].replace(r'"', r'`').replace(r"'", r'`')
+            line = 'DEFAULT'.join(parts)
+
+    # And now we convert it back (see above)
+    if re.match(r".*, ``\);", line):
+        line = re.sub(r'``\);', r"'');", line)
+
+    if searching_for_end and re.match(r'.*\);', line):
+        searching_for_end = False
+
+    if re.match(r"CREATE INDEX", line):
+        line = re.sub('"', '`', line)
+
+    if re.match(r"AUTOINCREMENT", line):
+        line = re.sub("AUTOINCREMENT", "AUTO_INCREMENT", line)
+
+    print(line),


### PR DESCRIPTION
This PR should add MySQL (mariadb) support to 3DS-RPC. Using MySQL has various benefits over SQLite like easy backups of the database, and allows the processes to write to the database at the same time. 

It's not exactly the neatest, but it works.

Made discord.py work, but discord rpc isn't really tested.

To enable MySQL support, change IS_SQLITE to false, then fill in all the auth stuff.

pls push pretendo to 3dsrpc.com

kthxbye