### PR TITLE
[Misc]: Add setup instructions and database python script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 # Python
 venv/
+.venv
 __pycache__/
 
 # IDEs

--- a/SETUP.md
+++ b/SETUP.md
@@ -1,0 +1,77 @@
+# 3DS-RPC Setup Instructions
+
+## 1. Configure environment variables and secrets
+
+First, copy the template:
+
+```
+cp template.private.py api/private.py
+```
+
+Open `api/private.py` and fill in all required secrets and configuration values as described in the file’s comments (e.g., DB_URL, CLIENT_ID, CLIENT_SECRET, HOST, etc).
+
+Adjust the values as needed for your environment.
+
+## 2. (Recommended) Create and activate a Python virtual environment
+
+Open a terminal in the project root and run:
+
+### On Windows:
+```
+python -m venv .venv
+.venv\Scripts\activate
+```
+
+### On Linux/macOS:
+```
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+This will create and activate a virtual environment for your dependencies.
+
+## 3. Install Python dependencies
+
+With the virtual environment activated, run:
+
+```
+pip install -r requirements.txt
+```
+
+## 4. Initialize the database
+
+Run the database reset script from the project root:
+
+### On Windows:
+```
+python sqlite/reset.py
+```
+
+### On Linux/macOS:
+```
+python3 sqlite/reset.py
+```
+
+This will create or reset the database using the schema in CREATE.sql.
+
+---
+
+## 5. Run the backend
+
+From the project root, start the backend for your desired network:
+
+```
+python backend.py --network nintendo
+```
+
+or
+
+```
+python backend.py --network pretendo
+```
+
+Replace `nintendo` or `pretendo` as needed.
+
+---
+
+You are now ready to run the backend!

--- a/sqlite/reset.py
+++ b/sqlite/reset.py
@@ -1,0 +1,21 @@
+import os
+import sqlite3
+
+base_dir = os.path.dirname(__file__)
+db_path = os.path.join(base_dir, "fcLibrary.db")
+sql_file = os.path.join(base_dir, "CREATE.sql")
+
+# Remove the database file if it exists
+if os.path.exists(db_path):
+    os.remove(db_path)
+
+# Read SQL commands from file
+with open(sql_file, "r", encoding="utf-8") as f:
+    sql_script = f.read()
+
+# Create new database and execute SQL script
+conn = sqlite3.connect(db_path)
+conn.executescript(sql_script)
+conn.close()
+
+print("Reset!")


### PR DESCRIPTION
When checking out https://github.com/3DS-RPC/3DS-RPC/pull/68 i noticed we didn't actually have a clean setup guide anymore apart from a sh script, so it didn't really work for windows etc.

- Added a SETUP.md that should help people get started when working on PR's
- Added a reset.py script in sqlite, so just running the python script will bootstrap the DB instead of depending on a sh file.