### PR TITLE
fix(backend): update heartbeat after each batch instead of after full queue

### DIFF
--- a/api/metrics.py
+++ b/api/metrics.py
@@ -85,6 +85,19 @@ def reset_metrics(network: NetworkType) -> None:
         session.commit()
 
 
+def update_backend_heartbeat(network: NetworkType) -> None:
+    """Update the last_loop_end_time heartbeat so the frontend doesn't mark us offline."""
+    from database import BackendMetrics as DBBackendMetrics
+    if db is None:
+        return
+    _ensure_metrics_record(network)
+    with db.session() as session:
+        record = session.query(DBBackendMetrics).filter_by(network=network).first()
+        if record:
+            record.last_loop_end_time = time.time()
+            session.commit()
+
+
 def _ensure_metrics_record(network: NetworkType) -> None:
     """Ensure a metrics record exists for the given network."""
     from database import BackendMetrics as DBBackendMetrics

--- a/backend.py
+++ b/backend.py
@@ -179,7 +179,7 @@ async def main():
 			except Exception as e:
 				print('An error occurred!\n%s' % e)
 				print(traceback.format_exc())
-				await anyio.sleep(2)
+				await anyio.sleep(DELAY_TABLE["SYNC_FRIENDS"])
 
 		if scrape_only:
 			print('Done scraping.')
@@ -188,13 +188,13 @@ async def main():
 		record_loop_end(users_processed_this_loop, network)
 		timestamp = dt.now().strftime('%Y-%m-%d %H:%M:%S')
 		duration = get_backend_metrics(network)["last_loop_duration_seconds"] or 0
-		delay = min(300, max(60, users_processed_this_loop))
+		queue_batch_delay = min(300, max(60, users_processed_this_loop))
 
 		# The delay scales with queue size to prevent overwhelming Pretendo:
 		#   - Minimum delay: 60 seconds (prevents loops from running too fast for small queues)
 		#   - Maximum delay: 300 seconds / 5 minutes (prevents excessive waiting for very large queues)
-		print(f"[{timestamp}] Processed {users_processed_this_loop} users in {duration:.2f}s, applying delay of {delay}s")
-		await anyio.sleep(delay)
+		print(f"[{timestamp}] Processed {users_processed_this_loop} users in {duration:.2f}s, applying delay of {queue_batch_delay}s")
+		await anyio.sleep(queue_batch_delay)
 
 
 async def main_friends_loop(friends_client: friends.FriendsClientV1, session: Session, current_rotation: list[QueriedFriend]):

--- a/backend.py
+++ b/backend.py
@@ -45,7 +45,7 @@ scrape_only: bool = False
 
 network: NetworkType = NetworkType.NINTENDO
 
-from api.metrics import record_loop_start, record_loop_end, get_backend_metrics, init_db, reset_metrics
+from api.metrics import record_loop_start, record_loop_end, get_backend_metrics, init_db, reset_metrics, update_backend_heartbeat
 from api.networks import NetworkType
 
 class QueriedFriend:
@@ -175,10 +175,12 @@ async def main():
 
 						# Begin our main loop!
 						await main_friends_loop(friends_client, session, batch)
+						update_backend_heartbeat(network)
 
 			except Exception as e:
 				print('An error occurred!\n%s' % e)
 				print(traceback.format_exc())
+				update_backend_heartbeat(network)
 				await anyio.sleep(DELAY_TABLE["SYNC_FRIENDS"])
 
 		if scrape_only:


### PR DESCRIPTION
### Hotfix for PR's new uptime check (#82)

The uptime heartbeat (`last_loop_end_time`) was only updated after processing the **entire** queue. When the queue required multiple batches (each up to ~5 minutes), total processing time could exceed the 5-minute `HEARTBEAT_THRESHOLD`, causing the frontend to incorrectly report the backend as **offline**, even though it was still actively working.

**Fix:** Update the heartbeat after **_each batch of up to 100 users_** so it stays fresh regardless of queue size.