### PR TITLE
fix(server): trust reverse proxy headers for https redirects

### DIFF
--- a/server.py
+++ b/server.py
@@ -4,6 +4,7 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
+from werkzeug.middleware.proxy_fix import ProxyFix
 import sys, datetime, xmltodict, pickle, secrets
 
 from sqlalchemy import select, update, insert, delete
@@ -16,6 +17,17 @@ from api.metrics import init_db
 from database import *
 
 app = Flask(__name__)
+
+# Trust the reverse proxy's forwarded headers so Flask sees the scheme the
+# client actually used (https), not the backend's http. Without this, Flask
+# generates http:// redirects that browsers block as mixed content.
+app.wsgi_app = ProxyFix(
+    app.wsgi_app,
+    x_for=1,
+    x_proto=1,
+    x_host=1,
+    x_port=1,
+)
 
 app.config["SQLALCHEMY_DATABASE_URI"] = get_db_url()
 


### PR DESCRIPTION
# Issue

The production version of 3dsrpc runs behind nginx, which terminates TLS. Because nginx forwards requests to Flask over HTTP, Flask was incorrectly detecting requests as `http://` and generating HTTP redirects.

When these redirects were returned on an HTTPS page, the browser blocked them as mixed content, causing console toggling and deletion actions to fail.

# FIx
Configured Flask's built-in `ProxyFix` middleware in `server.py` to trust the reverse proxy's `X-Forwarded-*` headers. 

<img width="810" height="155" alt="image" src="https://github.com/user-attachments/assets/a6367802-9278-41ed-a6c2-fabc28a5e1f9" />
