### PR TITLE
fix: clear stale online status so Discord RPC doesn't stick for offline users

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -14,7 +14,7 @@ import anyio, sys, argparse, time
 from database import start_db_time, get_db_url, Friend, DiscordFriends
 
 # Time in seconds before a user is considered "offline"
-OFFLINE_THRESHOLD = 30 * 60  # 30 minutes
+OFFLINE_THRESHOLD = 60 * 60
 OFFLINE_CHECK_INTERVAL = 10  # Check offline users every 10 loops
 
 # Delay table with descriptive names for each delay purpose
@@ -105,14 +105,13 @@ async def main():
 		record_loop_start(len(queried_friends), network)
 
 		all_friends: list[QueriedFriend] = list(map(QueriedFriend, queried_friends))
-		current_time = time.time()
 		
 		# Split friends into online and offline queues
 		online_queue = []
 		offline_queue = []
 		
 		for friend in all_friends:
-			if friend.online and (current_time - friend.last_online <= OFFLINE_THRESHOLD):
+			if friend.online:
 				online_queue.append(friend)
 			else:
 				offline_queue.append(friend)
@@ -186,6 +185,16 @@ async def main():
 		if scrape_only:
 			print('Done scraping.')
 			break
+
+		# Safety net: clear any stale "online" flags whose last_online is older than the offline threshold.
+		session.execute(
+			update(Friend)
+			.where(Friend.network == network)
+			.where(Friend.online == True)
+			.where(Friend.last_online < time.time() - OFFLINE_THRESHOLD)
+			.values(online=False, title_id=0, upd_id=0)
+		)
+		session.commit()
 
 		record_loop_end(users_processed_this_loop, network)
 		timestamp = dt.now().strftime('%Y-%m-%d %H:%M:%S')

--- a/discord.py
+++ b/discord.py
@@ -14,6 +14,9 @@ from requests.exceptions import HTTPError
 
 API_ENDPOINT: str = 'https://discord.com/api/v10'
 
+# Time in seconds before a user is considered "offline"
+OFFLINE_THRESHOLD: int = 60 * 60
+
 with open('./cache/databases.dat', 'rb') as file:
 	t = pickle.loads(file.read())
 	titleDatabase = t[0]
@@ -290,7 +293,7 @@ while True:
 
 		api_client = APIClient(discord_user)
 
-		if not friend_data.online:
+		if not friend_data.online or time.time() - friend_data.last_online > OFFLINE_THRESHOLD:
 			# If the user is offline, and they lack an RPC session,
 			# there's nothing for us to do.
 			if not discord_user.rpc_session_token:

--- a/server.py
+++ b/server.py
@@ -340,7 +340,7 @@ def sidenav():
     nintendo_metrics = get_backend_metrics(NetworkType.NINTENDO)
     pretendo_metrics = get_backend_metrics(NetworkType.PRETENDO)
     
-    HEARTBEAT_THRESHOLD = 5 * 60  # 5 minutes
+    HEARTBEAT_THRESHOLD = 10 * 60  # 10 minutes
     
     def is_online(metrics: dict | None) -> bool:
         if not metrics:


### PR DESCRIPTION
I'm not 100% sure this completely fixes statuses getting stuck, but it's worth addressing the possibility of stale status data on both ends. At the very least, this should resolve the issue on Discord's side.

Note: This also includes a commit that increases the metrics heartbeat interval from 5 to 10, as it was timing out on Pretendo.
