### PR TITLE
fix(backend): never auto-delete user consoles, unselect them when unfriended

### DIFF
--- a/backend.py
+++ b/backend.py
@@ -293,16 +293,19 @@ async def main_friends_loop(friends_client: friends.FriendsClientV1, session: Se
 		# This user must have removed us.
 		unfriended_codes.append(current_friend.friend_code)
 
-	# Batch delete unfriended users
+	# Stop tracking friends who removed us. We never delete the user's console
+	# (`discord_friends`), that is user-managed and may only be removed via the
+	# website's Delete button. We just unselect it so the bot stops using it, while the user keeps it listed.
 	if unfriended_codes:
 		for fc in unfriended_codes:
 			session.execute(delete(Friend).where(Friend.friend_code == fc).where(Friend.network == network))
-			session.execute(delete(DiscordFriends).where(
+			session.execute(update(DiscordFriends).where(
 				DiscordFriends.friend_code == fc,
 				DiscordFriends.network == network)
+				.values(active=False)
 			)
 		session.commit()
-		print(f'Removed {len(unfriended_codes)} unfriended users')
+		print(f'Stopped tracking {len(unfriended_codes)} unfriended users')
 
 	if len(added_friends) == 0:
 		# All of our friends removed us, so there's no more work to be done.

--- a/server.py
+++ b/server.py
@@ -694,7 +694,7 @@ def consoles():
         result = db.session.scalar(stmt)
         data['consoles'].append({
             'fc': '-'.join(console[i:i+4] for i in range(0, 12, 4)),
-            'username': result.username,
+            'username': result.username if result else 'Not tracked',
             'active': active,
             'network': network.lower_name()
         })


### PR DESCRIPTION
So, it looks like the console deletion bug has returned. I took a look through the code, and I believe the issue is related to how the database is structured.

As a temporary fix, I've changed the backend so it can no longer automatically delete console links. Instead, it will simply unselect the active user.

_**This does mean we'll continue storing Discord and console links for now.**_ However, users can still delete console links through the website as normal. This change only prevents the backend from doing it automatically and acts as a temporary workaround until we identify the root cause.
